### PR TITLE
bug/WDP190703/fix-product-box

### DIFF
--- a/src/partials/20_section-hot-deals.html
+++ b/src/partials/20_section-hot-deals.html
@@ -3,9 +3,9 @@
     <div class="deals">
       <div class="row">
         <div class="col-xl-4 col-lg-4">
-          <div class="product-box">
+          <div class="product-box product-box-hot-deals">
             <div class="photo">
-              <img src="images/ad2.png" alt="" class="furniture-photo">
+              <img src="images/ad2.png" alt="" class="furniture-photo" />
               <div class="hot-deals-head">
                 <p>hot deals</p>
                 <div class="dots">
@@ -61,7 +61,7 @@
         </div>
         <div class="col-xl-8 col-lg-8 col-md-12 col-sm-12 col-12">
           <div class="banner">
-            <img src="./images/advertisement.png" alt="" class="advertisement-photo">
+            <img src="./images/advertisement.png" alt="" class="advertisement-photo" />
             <div class="slogan">
               <div class="title">
                 <div class="word1">indor</div>

--- a/src/sass/components/_section-hot-deals.scss
+++ b/src/sass/components/_section-hot-deals.scss
@@ -1,7 +1,7 @@
 .deals {
   position: relative;
 
-  .product-box {
+  .product-box-hot-deals {
     .photo {
       @include hover-only {
         &:hover {
@@ -220,7 +220,7 @@
 }
 
 @media (max-width: 576px) {
-  .product-box {
+  .product-box-hot-deals {
     display: none;
   }
 
@@ -241,7 +241,7 @@
 }
 
 @media (min-width: 577px) {
-  .product-box {
+  .product-box-hot-deals {
     display: none;
   }
 
@@ -263,7 +263,7 @@
 }
 
 @media (min-width: 993px) {
-  .product-box {
+  .product-box-hot-deals {
     display: block;
 
     .stats {
@@ -292,7 +292,7 @@
 }
 
 @media (min-width: 1200px) {
-  .product-box {
+  .product-box-hot-deals {
     display: block;
 
     .stats {


### PR DESCRIPTION
I found out that after adding the hot deals section, at lower resolutions the items from new furniture section disappeared. 

In scss from hot-deals, the product-box classes were edited. I just added to the .product-box inside hot deals section a new class of .product-box-hot-deals and changed all ".product-box" inside hot deals scss to the ".product-box-hot-deals"