### PR TITLE
bug/WDP190703-36/product-box-btn-pos-fix

### DIFF
--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -81,6 +81,7 @@
       display: flex;
       justify-content: space-between;
       position: relative;
+      margin-top: -1px;
     }
   }
 


### PR DESCRIPTION
Fixed the positioning of buttons inside product boxes.

Decided to do it with negative margin rather than with transform-translateY. What do you think?